### PR TITLE
Document follow-up QA tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,21 @@
+# Follow-up Maintenance Tasks
+
+## 1. Correct typo in setup instructions
+- **Issue**: The quick setup guide says "create one if you don't have it," which should read "create one if you don't have one." The current wording is grammatically incorrect and reads like a typo in the onboarding docs.
+- **Proposed fix**: Update the sentence in `SETUP_INSTRUCTIONS.md` so it uses the proper pronoun.
+- **Why it matters**: Polished documentation avoids confusing new contributors and keeps the instructions professional.
+
+## 2. Refresh local inspection cache after updates
+- **Issue**: `useInspections.saveInspection` only refreshes cached inspections when a new record is inserted. When an existing inspection is updated, the hook returns without refetching, so the UI continues to show stale data until the page reloads.
+- **Proposed fix**: After a successful update, either call `fetchInspections()` or update the `inspections` state with the latest payload before returning.
+- **Why it matters**: Users expect edits to appear immediately; without the refresh they see outdated information, which looks like their changes were lost.
+
+## 3. Align environment setup docs with the repository
+- **Issue**: Several onboarding instructions (banner copy and setup guides) tell developers to copy `.env.local.example`, but that file is not present in the repo.
+- **Proposed fix**: Either add the missing template file or update the docs/UI copy to describe the real setup steps (for example, list the required variables directly).
+- **Why it matters**: Following the published instructions currently fails, causing unnecessary setup friction.
+
+## 4. Add unit coverage for invoice validation helpers
+- **Issue**: `lib/invoice-validation.ts` contains the core validation logic for invoices, but there are no automated tests covering the different validation branches (e.g., property-based totals, email validation, amount constraints, and `suggestInvoiceStatus`).
+- **Proposed fix**: Introduce Jest or Vitest specs that exercise `validateInvoice`, `canFinalizeInvoice`, and `suggestInvoiceStatus` across happy-path and failure scenarios.
+- **Why it matters**: Test coverage will guard against regressions in billing logic and provide documentation for expected behaviors.

--- a/components/invoice-list.tsx
+++ b/components/invoice-list.tsx
@@ -8,7 +8,7 @@ interface InvoiceListProps {
   invoices: Invoice[]
   onEdit: (invoice: Invoice) => void
   onDelete: (id: string) => void
-  onExportPDF: (invoice: Invoice) => void
+  onExportPDF: (invoice: Invoice) => Promise<void>
   loading?: boolean
 }
 

--- a/components/invoice-section.tsx
+++ b/components/invoice-section.tsx
@@ -51,9 +51,9 @@ export function InvoiceSection() {
     }
   }
 
-  const handleExportPDF = (invoice: Invoice) => {
+  const handleExportPDF = async (invoice: Invoice) => {
     try {
-      generateInvoicePDF(invoice)
+      await generateInvoicePDF(invoice)
     } catch (error) {
       console.error('Error generating PDF:', error)
       alert('Failed to generate PDF. Please try again.')

--- a/lib/pdf/invoice-pdf.ts
+++ b/lib/pdf/invoice-pdf.ts
@@ -1,5 +1,3 @@
-import jsPDF from 'jspdf'
-import 'jspdf-autotable'
 import type { Invoice } from '@/types'
 
 // Extend jsPDF type to include autoTable
@@ -9,7 +7,11 @@ declare module 'jspdf' {
   }
 }
 
-export function generateInvoicePDF(invoice: Invoice): void {
+export async function generateInvoicePDF(invoice: Invoice): Promise<void> {
+  // Dynamically import pdf libraries to avoid SSR "window is not defined" errors
+  const { default: jsPDF } = await import('jspdf')
+  await import('jspdf-autotable')
+
   const doc = new jsPDF()
   const pageWidth = doc.internal.pageSize.width
   const pageHeight = doc.internal.pageSize.height


### PR DESCRIPTION
## Summary
- add TASKS.md capturing follow-up work for a typo, a stale inspection refresh bug, an environment setup doc gap, and missing invoice validation tests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd4e1cea58832f9867dea7830c3613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Exporting invoices now completes reliably before the UI proceeds, preventing unfinished exports or race conditions during PDF generation.
* **Documentation**
  * Added a maintenance task list: fix a setup instruction typo; align environment setup guidance with repository (example env expectations); recommend refreshing local inspection cache after updates; proposed unit-test plans for invoice validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->